### PR TITLE
Drop gid before uid to avoid permission errors

### DIFF
--- a/dns-proxy.c
+++ b/dns-proxy.c
@@ -292,13 +292,13 @@ int udp_listener() {
 
 	if (geteuid() == 0) {
 
-		if(setuid(getpwnam(USERNAME)->pw_uid) != 0) {
-			printf("setuid: Unable to drop to %s, %s",USERNAME,strerror(errno));
+		if(setgid(getgrnam(GROUPNAME)->gr_gid) != 0) {
+			printf("setgid: Unable to drop to %s, %s",GROUPNAME,strerror(errno));
 			exit(1);
 		}
 
-		if(setgid(getgrnam(GROUPNAME)->gr_gid) != 0) {
-			printf("setgid: Unable to drop to %s, %s",GROUPNAME,strerror(errno));
+		if(setuid(getpwnam(USERNAME)->pw_uid) != 0) {
+			printf("setuid: Unable to drop to %s, %s",USERNAME,strerror(errno));
 			exit(1);
 		}
 


### PR DESCRIPTION
On Debian (and quite possibly other distros too), processes running as user `nobody` are not allowed to change their gid regardless of whether their group is still `root`. That means we need to give up our group before our user, or else we get a permission error when calling `setgid()`.